### PR TITLE
feat(jira-clone): add edit and delete task functionality Implement ed…

### DIFF
--- a/apps/jira-clone/README.md
+++ b/apps/jira-clone/README.md
@@ -392,6 +392,9 @@ Task filters are managed using URL query parameters, allowing for:
     - Assignee selection
     - Due date setting
     - Automatic position calculation for ordering
+  - `DELETE /api/tasks/:taskId` - Delete task
+  - `PATCH /api/tasks/:taskId` - Update task
+  - `GET /api/tasks/:taskId` - Get single task
 
 ### Task Components
 - `TaskViewSwitcher`: Manages view transitions with:
@@ -413,10 +416,15 @@ Task filters are managed using URL query parameters, allowing for:
   - `useCreateTask` - Handles task creation with mutations
   - `useGetTasks` - Fetches tasks with filtering
   - `useCreateTaskModal` - Manages task creation modal state
+  - `useUpdateTasks` - Handle task updates
+  - `useDeleteTasks` - Handle task deletion
+  - `useGetTask` - Fetch single task data
 
 - **Components**:
   - `CreateTaskModal` - Responsive modal for task creation
   - `CreateTaskFormWrapper` - Form handling component
+  - `UpdateTaskModal` - Responsive modal for task updation
+  - `UpdateTaskFormWrapper` - Form handling component
   - `DatePicker` - Custom date selection component
 
 - **State Management**:

--- a/apps/jira-clone/app/(dashboard)/layout.tsx
+++ b/apps/jira-clone/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { Navbar } from "@/components/Navbar";
 import { Sidebar } from "@/components/sidebar";
 import { CreateProjectModal } from "@/features/projects/components/create-project-modal";
 import { CreateTaskModal } from "@/features/tasks/components/create-task-modal";
+import { EditTaskModal } from "@/features/tasks/components/edit-task-modal";
 import { CreateWorkspaceModal } from "@/features/workspaces/components/create-workspace-modal";
 import { Suspense } from "react";
 
@@ -16,6 +17,7 @@ const DashboardLayout = ({ children }: layoutProps) => {
         <CreateWorkspaceModal />
         <CreateProjectModal />
         <CreateTaskModal />
+        <EditTaskModal />
       </Suspense>
 
       <div className=" flex w-full h-full">

--- a/apps/jira-clone/features/projects/components/edit-project-form.tsx
+++ b/apps/jira-clone/features/projects/components/edit-project-form.tsx
@@ -43,7 +43,7 @@ export const EditProjectForm = ({
   const { mutate: deleteProject, isPending: isDeletingProject } =
     useDeleteProject();
 
-  const [DeleteDiealog, confirmDelete] = useConfirm(
+  const [DeleteDialog, confirmDelete] = useConfirm(
     "Delete Project",
     "This action can not be undone.",
     "destructive",
@@ -94,7 +94,7 @@ export const EditProjectForm = ({
 
   return (
     <div className="flex flex-col  gap-y-4">
-      <DeleteDiealog />
+      <DeleteDialog />
       <Card className="w-full h-full border-none shadow-none">
         <CardHeader className="flex p-7 gap-x-4 flex-row items-center space-y-0">
           <Button

--- a/apps/jira-clone/features/tasks/api/use-delete-tasks.ts
+++ b/apps/jira-clone/features/tasks/api/use-delete-tasks.ts
@@ -1,0 +1,41 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { InferRequestType, InferResponseType } from "hono";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+// Extract response and request types from the login endpoint
+type ResponseType = InferResponseType<
+  (typeof client.api.tasks)[":taskId"]["$delete"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.tasks)[":taskId"]["$delete"]
+>;
+
+export const useDeleteTask = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param }) => {
+      const response = await client.api.tasks[":taskId"].$delete({ param });
+
+      if (!response.ok) {
+        throw new Error("Failed to delete task");
+      }
+
+      return await response.json();
+    },
+    onSuccess: ({ data }) => {
+      toast.success("task delete successfully");
+      router.refresh();
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["task", data.$id] });
+    },
+    onError: () => {
+      toast.error("Failed to delete task");
+    },
+  });
+  return mutation;
+};

--- a/apps/jira-clone/features/tasks/api/use-get-task.ts
+++ b/apps/jira-clone/features/tasks/api/use-get-task.ts
@@ -1,0 +1,24 @@
+import type { TaskStatus } from "@/features/tasks/types";
+import { client } from "@/lib/rpc";
+import { useQuery } from "@tanstack/react-query";
+
+interface UseGetTaskProps {
+  taskId: string;
+}
+
+export const useGetTask = ({ taskId }: UseGetTaskProps) => {
+  const query = useQuery({
+    queryKey: ["task", taskId],
+    queryFn: async () => {
+      const response = await client.api.tasks[":taskId"].$get({
+        param: { taskId },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to fetch task");
+      }
+      const { data } = await response.json();
+      return data;
+    },
+  });
+  return query;
+};

--- a/apps/jira-clone/features/tasks/api/use-update-tasks.ts
+++ b/apps/jira-clone/features/tasks/api/use-update-tasks.ts
@@ -1,0 +1,44 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { InferRequestType, InferResponseType } from "hono";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+// Extract response and request types from the login endpoint
+type ResponseType = InferResponseType<
+  (typeof client.api.tasks)[":taskId"]["$patch"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.tasks)[":taskId"]["$patch"]
+>;
+
+export const useUpdateTask = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const mutation = useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ json, param }) => {
+      const response = await client.api.tasks[":taskId"].$patch({
+        json,
+        param,
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to update task");
+      }
+
+      return await response.json();
+    },
+    onSuccess: ({ data }) => {
+      toast.success("task updated successfully");
+      router.refresh();
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["task", data.$id] });
+    },
+    onError: () => {
+      toast.error("Failed to update task");
+    },
+  });
+  return mutation;
+};

--- a/apps/jira-clone/features/tasks/components/create-task-modal.tsx
+++ b/apps/jira-clone/features/tasks/components/create-task-modal.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { ResponsiveModal } from "@/components/responsive-modal";
-import { useCreateTaskModal } from "../hooks/use-create-task-modal";
-import { CreateTaskFormWrapper } from "./create-task-form-wrapper";
+import { CreateTaskFormWrapper } from "@/features/tasks/components/create-task-form-wrapper";
+import { useCreateTaskModal } from "@/features/tasks/hooks/use-create-task-modal";
 
 export const CreateTaskModal = () => {
   const { isOpen, setIsOpen, close } = useCreateTaskModal();

--- a/apps/jira-clone/features/tasks/components/edit-task-form-wrapper.tsx
+++ b/apps/jira-clone/features/tasks/components/edit-task-form-wrapper.tsx
@@ -1,0 +1,67 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { useGetMembers } from "@/features/members/api/use-get-members";
+import { useGetProjects } from "@/features/projects/api/use-get-projects";
+import { useGetTask } from "@/features/tasks/api/use-get-task";
+import { CreateTaskForm } from "@/features/tasks/components/create-task-form";
+import { EditTaskForm } from "@/features/tasks/components/edit-task-form";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { Loader } from "lucide-react";
+
+interface EditTaskFormWrapperProps {
+  onCancel: () => void;
+  id: string;
+}
+
+export const EditTaskFormWrapper = ({
+  onCancel,
+  id,
+}: EditTaskFormWrapperProps) => {
+  const workspaceId = useWorkspaceId();
+
+  const { data: initialValues, isLoading: isLoadingTask } = useGetTask({
+    taskId: id,
+  });
+
+  const { data: projects, isLoading: isLoadingProjects } = useGetProjects({
+    workspaceId,
+  });
+  const { data: members, isLoading: isLoadingMembers } = useGetMembers({
+    workspaceId,
+  });
+
+  const projectOptions = projects?.documents.map((project) => ({
+    id: project.$id,
+    name: project.name,
+    imageUrl: project.imageUrl,
+  }));
+
+  const memberOptions = members?.documents.map((member) => ({
+    id: member.$id,
+    name: member.name,
+  }));
+
+  const isLoading = isLoadingProjects || isLoadingMembers || isLoadingTask;
+
+  if (isLoading) {
+    return (
+      <Card className="w-full h-[714px] border-none shadow-none ">
+        <CardContent className="flex items-center justify-center h-full ">
+          <Loader className="size-5 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!initialValues) {
+    return null;
+  }
+
+  return (
+    <EditTaskForm
+      onCancel={onCancel}
+      initialValues={initialValues}
+      projectOptions={projectOptions ?? []}
+      memberOptions={memberOptions ?? []}
+    />
+  );
+};

--- a/apps/jira-clone/features/tasks/components/edit-task-form.tsx
+++ b/apps/jira-clone/features/tasks/components/edit-task-form.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { DottedSeprator } from "@/components/dotted-seprator";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DatePicker } from "@/components/ui/date-picker";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { MemberAvatar } from "@/features/members/components/member-avatar";
+import { ProjectAvatar } from "@/features/projects/components/project-avatar";
+import { useUpdateTask } from "@/features/tasks/api/use-update-tasks";
+import { createTaskSchema } from "@/features/tasks/schemas";
+import { type Task, TaskStatus } from "@/features/tasks/types";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { cn } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useRef } from "react";
+import { useForm } from "react-hook-form";
+import type { z } from "zod";
+
+interface EditTaskFormProps {
+  onCancel?: () => void;
+  projectOptions: { id: string; name: string; imageUrl: string }[];
+  memberOptions: { id: string; name: string }[];
+  initialValues: Task;
+}
+
+export const EditTaskForm = ({
+  onCancel,
+  projectOptions,
+  memberOptions,
+  initialValues,
+}: EditTaskFormProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { mutate, isPending } = useUpdateTask();
+  const router = useRouter();
+  const workspaceId = useWorkspaceId();
+
+  const form = useForm<z.infer<typeof createTaskSchema>>({
+    resolver: zodResolver(
+      createTaskSchema.omit({ workspaceId: true, description: true }),
+    ),
+    defaultValues: {
+      ...initialValues,
+      dueDate: initialValues.dueDate
+        ? new Date(initialValues.dueDate)
+        : undefined,
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof createTaskSchema>) => {
+    mutate(
+      { json: values, param: { taskId: initialValues.$id } },
+      {
+        onSuccess: () => {
+          form.reset();
+          onCancel?.();
+        },
+      },
+    );
+  };
+  return (
+    <Card className="w-full h-full border-none shadow-none">
+      <CardHeader className="flex p-7">
+        <CardTitle className="text-xl font-bold">Edit task</CardTitle>
+      </CardHeader>
+      <div className="px-7">
+        <DottedSeprator />
+      </div>
+      <CardContent className="p-7">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="flex flex-col gap-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Task Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="Enter task name" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="dueDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Due Date</FormLabel>
+                    <FormControl>
+                      <DatePicker {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="assigneeId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Assignee</FormLabel>
+                    <Select
+                      defaultValue={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select assignee" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <FormMessage />
+                      <SelectContent>
+                        {memberOptions.map((member) => (
+                          <SelectItem key={member.id} value={member.id}>
+                            <div className="flex items-center gap-x-2 ">
+                              <MemberAvatar
+                                name={member.name}
+                                className="size-6"
+                              />
+                              {member.name}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="status"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Status</FormLabel>
+                    <Select
+                      defaultValue={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select status" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <FormMessage />
+                      <SelectContent>
+                        <SelectItem value={TaskStatus.BACKLOG}>
+                          Backlog
+                        </SelectItem>
+                        <SelectItem value={TaskStatus.IN_PROGRESS}>
+                          In Progress
+                        </SelectItem>
+                        <SelectItem value={TaskStatus.IN_REVIEW}>
+                          In Review
+                        </SelectItem>
+                        <SelectItem value={TaskStatus.TODO}>Todo</SelectItem>
+                        <SelectItem value={TaskStatus.DONE}>Done</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="projectId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Project</FormLabel>
+                    <Select
+                      defaultValue={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select project" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <FormMessage />
+                      <SelectContent>
+                        {projectOptions.map((project) => (
+                          <SelectItem key={project.id} value={project.id}>
+                            <div className="flex items-center gap-x-2 ">
+                              <ProjectAvatar
+                                image={project.imageUrl}
+                                name={project.name}
+                                className="size-6"
+                              />
+                              {project.name}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+            </div>
+            <DottedSeprator className="py-7" />
+            <div className="flex items-center justify-between">
+              <Button
+                type="button"
+                size="lg"
+                variant="secondary"
+                disabled={isPending}
+                onClick={onCancel}
+                className={cn(!onCancel && "invisible")}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="lg" disabled={isPending}>
+                Save Changes
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/jira-clone/features/tasks/components/edit-task-modal.tsx
+++ b/apps/jira-clone/features/tasks/components/edit-task-modal.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { ResponsiveModal } from "@/components/responsive-modal";
+import { EditTaskFormWrapper } from "@/features/tasks/components/edit-task-form-wrapper";
+import { useEditTaskModal } from "@/features/tasks/hooks/use-edit-task-modal";
+
+export const EditTaskModal = () => {
+  const { taskId, setTaskId, close } = useEditTaskModal();
+
+  return (
+    <ResponsiveModal open={!!taskId} onOpenChange={close}>
+      {taskId && <EditTaskFormWrapper id={taskId} onCancel={close} />}
+    </ResponsiveModal>
+  );
+};

--- a/apps/jira-clone/features/tasks/components/task-actions.tsx
+++ b/apps/jira-clone/features/tasks/components/task-actions.tsx
@@ -4,7 +4,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useDeleteTask } from "@/features/tasks/api/use-delete-tasks";
+import { useEditTaskModal } from "@/features/tasks/hooks/use-edit-task-modal";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { useConfirm } from "@/hooks/use-confirm";
 import { ExternalLinkIcon, PencilIcon, TrashIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
 
 interface TaskActionsProps {
   id: string;
@@ -13,39 +18,64 @@ interface TaskActionsProps {
 }
 
 export const TaskActions = ({ id, projectId, children }: TaskActionsProps) => {
+  const workspaceId = useWorkspaceId();
+  const router = useRouter();
+
+  const { open } = useEditTaskModal();
+
+  const [ConfrimDialog, confirm] = useConfirm(
+    "Delete task",
+    "This action can not be undone.",
+    "destructive",
+  );
+
+  const { mutate, isPending } = useDeleteTask();
+
+  const onOpenProject = () => {
+    router.push(`/workspaces/${workspaceId}/projects/${projectId}`);
+  };
+
+  const onOpenTask = () => {
+    router.push(`/workspaces/${workspaceId}/tasks/${id}`);
+  };
+
+  const handleDelete = async () => {
+    const ok = await confirm();
+    if (!ok) return;
+    mutate({ param: { taskId: id } });
+  };
+
   return (
     <div className="flex justify-end">
+      <ConfrimDialog />
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
           <DropdownMenuItem
-            onClick={() => {}}
+            onClick={onOpenTask}
             className="font-medium p-[10px]"
-            disabled={false}
           >
             <ExternalLinkIcon className="w-4 mr-2 stroke-2" />
             Task Details
           </DropdownMenuItem>
           <DropdownMenuItem
-            onClick={() => {}}
+            onClick={onOpenProject}
             className="font-medium p-[10px]"
-            disabled={false}
           >
             <ExternalLinkIcon className="w-4 mr-2 stroke-2" />
             Open Project
           </DropdownMenuItem>
           <DropdownMenuItem
-            onClick={() => {}}
+            onClick={() => open(id)}
             className="font-medium p-[10px]"
-            disabled={false}
           >
             <PencilIcon className="w-4 mr-2 stroke-2" />
             Edit Task
           </DropdownMenuItem>
           <DropdownMenuItem
-            onClick={() => {}}
+            onClick={handleDelete}
             className="text-amber-700 focus:text-amber-700 font-medium p-[10px]"
-            disabled={false}
+            disabled={isPending}
           >
             <TrashIcon className="w-4 mr-2 stroke-2" />
             Delete Task

--- a/apps/jira-clone/features/tasks/hooks/use-edit-task-modal.ts
+++ b/apps/jira-clone/features/tasks/hooks/use-edit-task-modal.ts
@@ -1,0 +1,15 @@
+import { parseAsString, useQueryState } from "nuqs";
+
+export const useEditTaskModal = () => {
+  const [taskId, setTaskId] = useQueryState("edit-task", parseAsString);
+
+  const open = (id: string) => setTaskId(id);
+  const close = () => setTaskId(null);
+
+  return {
+    taskId,
+    open,
+    close,
+    setTaskId,
+  };
+};

--- a/apps/jira-clone/features/tasks/server/route.ts
+++ b/apps/jira-clone/features/tasks/server/route.ts
@@ -10,6 +10,33 @@ import { Hono } from "hono";
 import { ID, Query } from "node-appwrite";
 
 const app = new Hono()
+
+  .delete("/:taskId", sessionMiddleware, async (c) => {
+    const user = c.get("user");
+    const databases = c.get("databases");
+    const { taskId } = c.req.param();
+
+    const task = await databases.getDocument<Task>(
+      DATABASE_ID,
+      TASKS_ID,
+      taskId,
+    );
+
+    const member = await getMember({
+      databases,
+      workspaceId: task.workspaceId,
+      userId: user.$id,
+    });
+
+    if (!member) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    await databases.deleteDocument(DATABASE_ID, TASKS_ID, taskId);
+
+    return c.json({ data: { $id: task.$id } });
+  })
+
   .get(
     "/",
     sessionMiddleware,
@@ -171,6 +198,106 @@ const app = new Hono()
 
       return c.json({ data: task });
     },
-  );
+  )
+  .patch(
+    "/:taskId",
+    sessionMiddleware,
+    zValidator("json", createTaskSchema.partial()),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const {
+        name,
+        status,
+        workspaceId,
+        projectId,
+        description,
+        assigneeId,
+        dueDate,
+      } = c.req.valid("json");
+      const { taskId } = c.req.param();
+      const existingTask = await databases.getDocument<Task>(
+        DATABASE_ID,
+        TASKS_ID,
+        taskId,
+      );
+
+      const member = await getMember({
+        databases,
+        workspaceId: existingTask.workspaceId,
+        userId: user.$id,
+      });
+
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const task = await databases.updateDocument(
+        DATABASE_ID,
+        TASKS_ID,
+        taskId,
+        {
+          name,
+          status,
+          projectId,
+          dueDate,
+          assigneeId,
+          description,
+        },
+      );
+
+      return c.json({ data: task });
+    },
+  )
+  .get("/:taskId", sessionMiddleware, async (c) => {
+    const currentUser = c.get("user");
+    const databases = c.get("databases");
+    const { taskId } = c.req.param();
+    const { users } = await createAdminClient();
+
+    const task = await databases.getDocument<Task>(
+      DATABASE_ID,
+      TASKS_ID,
+      taskId,
+    );
+
+    const currentMember = await getMember({
+      databases,
+      workspaceId: task.workspaceId,
+      userId: currentUser.$id,
+    });
+
+    if (!currentMember) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const project = await databases.getDocument<Project>(
+      DATABASE_ID,
+      PROJECTS_ID,
+      task.projectId,
+    );
+
+    const member = await databases.getDocument(
+      DATABASE_ID,
+      MEMBERS_ID,
+      task.assigneeId,
+    );
+
+    const user = await users.get(member.userId);
+
+    const assignee = {
+      ...member,
+      name: user.name,
+      email: user.email,
+    };
+
+    return c.json({
+      data: {
+        ...task,
+        project,
+        assignee,
+      },
+    });
+  });
 
 export default app;

--- a/apps/jira-clone/features/tasks/types.ts
+++ b/apps/jira-clone/features/tasks/types.ts
@@ -15,4 +15,5 @@ export type Task = Models.Document & {
   assigneeId: string;
   projectId: string;
   position: number;
+  workspaceId: string;
 };

--- a/apps/jira-clone/features/workspaces/components/edit-workspace-form.tsx
+++ b/apps/jira-clone/features/workspaces/components/edit-workspace-form.tsx
@@ -45,7 +45,7 @@ export const EditWorkspaceForm = ({
     useResetInviteCode();
   const router = useRouter();
 
-  const [DeleteDiealog, confirmDelete] = useConfirm(
+  const [DeleteDialog, confirmDelete] = useConfirm(
     "Delete Workspace",
     "This action can not be undone.",
     "destructive",
@@ -114,7 +114,7 @@ export const EditWorkspaceForm = ({
 
   return (
     <div className="flex flex-col  gap-y-4">
-      <DeleteDiealog />
+      <DeleteDialog />
       <ResetDialog />
       <Card className="w-full h-full border-none shadow-none">
         <CardHeader className="flex p-7 gap-x-4 flex-row items-center space-y-0">


### PR DESCRIPTION

This pull request includes several updates to the `jira-clone` application, focusing on task management functionalities. The changes introduce new API endpoints, hooks, and components for handling task operations such as creating, updating, and deleting tasks.

### API Enhancements:
* Added new API endpoints for tasks: `DELETE /api/tasks/:taskId`, `PATCH /api/tasks/:taskId`, and `GET /api/tasks/:taskId` in `README.md` to document the task operations.
* Introduced hooks for task operations: `useUpdateTasks`, `useDeleteTasks`, and `useGetTask`.

### Component Updates:
* Added `EditTaskModal` and `EditTaskFormWrapper` components to handle task editing. [[1]](diffhunk://#diff-3e32bf322da7f5d80623cc4095b161eadfee4426169cb5fb2d31a87ff3e75677R5) [[2]](diffhunk://#diff-3e32bf322da7f5d80623cc4095b161eadfee4426169cb5fb2d31a87ff3e75677R20)
* Created `EditTaskForm` component to provide a form for editing task details.
* Updated `CreateTaskModal` to use consistent import paths.

### Hook Implementations:
* Implemented `useDeleteTask` hook for handling task deletion with mutation and query invalidation.
* Implemented `useGetTask` hook for fetching single task data.
* Implemented `useUpdateTask` hook for handling task updates with mutation and query invalidation.

### Minor Fixes:
* Corrected typo in `EditProjectForm` from `DeleteDiealog` to `DeleteDialog`. [[1]](diffhunk://#diff-f15126893b2cdc0ba4097a313d09e56b36730c8ea01773c2ac1286c33522ba72L46-R46) [[2]](diffhunk://#diff-f15126893b2cdc0ba4097a313d09e56b36730c8ea01773c2ac1286c33522ba72L97-R97)

These changes collectively enhance the task management capabilities of the `jira-clone` application, providing more robust and user-friendly features for task operations.